### PR TITLE
Tagline Visible for Mobile Sizes

### DIFF
--- a/css/sass/media-queries.scss
+++ b/css/sass/media-queries.scss
@@ -215,7 +215,7 @@
 		#description {
 
 			#site-description {
-				display: none;
+				font-size: 25px;
 			}
 
 		}
@@ -309,14 +309,6 @@
 		#title {
 
 			#site-title {
-				font-size: 40px;
-			}
-
-		}
-
-		#description {
-
-			#site-description {
 				font-size: 40px;
 			}
 

--- a/css/style.css
+++ b/css/style.css
@@ -889,7 +889,7 @@ h3.jp-relatedposts-headline {
   #masthead #title #site-title {
     text-align: center; }
   #masthead #description #site-description {
-    display: none; }
+    font-size:25px; }
 
   #sidebar {
     background: #ffffff; }
@@ -922,8 +922,6 @@ h3.jp-relatedposts-headline {
       text-align: center; } }
 @media (max-width: 640px) {
   #masthead #title #site-title {
-    font-size: 40px; }
-  #masthead #description #site-description {
     font-size: 40px; }
 
   #primary-wrapper #primary {


### PR DESCRIPTION
Updated .scss files (updated /css/style.css to reflect changes) to make the tagline visible at mobile sizes, set a font-size.

Also removed an unneeded rule from the tiny (<640px) media query as it was unneeded (element was originally intended to be set to `display: none;` at that point).